### PR TITLE
Storage::getUrlFromPath() can return null

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -33,7 +33,7 @@ class Storage
         return $path;
     }
 
-    public function getUrlFromPath(string $path): string
+    public function getUrlFromPath(string $path): ?string
     {
         $pathHash = $this->createLocalPathHash($path);
 

--- a/tests/StorageTest.php
+++ b/tests/StorageTest.php
@@ -124,6 +124,7 @@ class StorageTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($webPageUrl, $this->storage->getUrlFromPath($webPagePath));
         $this->assertEquals($cssResourceUrl, $this->storage->getUrlFromPath($cssResourcePath));
+        $this->assertNull($this->storage->getUrlFromPath('foo'));
     }
 
     public function testReset()


### PR DESCRIPTION
Fixes #7 